### PR TITLE
lib/bindings: guard for position being undefined

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -73,7 +73,7 @@ exports.open = function(path, flags, mode, req) {
 
 exports.read = function(fd, buffer, offset, length, position, req) {
 	let callback = req ? req.oncomplete.bind(req) : null;
-	if (position !== -1) {
+	if (typeof position === 'number' && position !== -1) {
 		return syscall.pread64(fd, buffer.slice(offset, offset + length), position, callback);
 	} else {
 		return syscall.read(fd, buffer.slice(offset, offset + length), callback);
@@ -118,7 +118,7 @@ exports.utimes = function() {
 
 exports.writeBuffer = function(fd, buffer, offset, length, position, req) {
 	let callback = req ? req.oncomplete.bind(req) : null;
-	if (position !== -1) {
+	if (typeof position === 'number' && position !== -1) {
 		return syscall.pwrite64(fd, buffer.slice(offset, offset + length), position, callback);
 	} else {
 		return syscall.write(fd, buffer.slice(offset, offset + length), callback);


### PR DESCRIPTION
The implementation for fs.createReadStream() passes undefined as the
position argument which caused the binding to incorrectly use the
pread() system call.

Fixes #3