### PR TITLE
Add support for async JS based block operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
-  - "iojs-v1.0.4"
+  - "6"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - bc
+      - g++-4.8

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,8 @@
 			"target_name": "bindings",
 			"sources": [
 				"src/node_lkl.cc",
+				"src/disk.cc",
+				"src/async.cc",
 				"src/bindings.cc"
 			],
 			'actions': [

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -311,5 +311,10 @@ module.exports = {
 	SYS_wait4:                   260,
 	SYS_waitid:                  95,
 	SYS_write:                   64,
-	SYS_writev:                  66
+	SYS_writev:                  66,
+
+	LKL_DEV_BLK_TYPE_READ:       0,
+	LKL_DEV_BLK_TYPE_WRITE:      1,
+	LKL_DEV_BLK_TYPE_FLUSH:      4,
+	LKL_DEV_BLK_TYPE_FLUSH_OUT:  5
 }

--- a/lib/disk.js
+++ b/lib/disk.js
@@ -1,0 +1,68 @@
+const EventEmitter = require('events');
+const fs = require('fs');
+
+const constants = require('./constants');
+
+class FileDisk extends EventEmitter {
+	constructor(path) {
+		super();
+		this.path = path;
+		this.fd = null;
+
+		this.open();
+	}
+
+	open() {
+		const self = this;
+		// FIXME: allow opening the file readonly
+		fs.open(this.path, 'r+', function(err, fd) {
+			if (err) {
+				self.fd = -1;
+				return;
+			}
+			self.fd = fd;
+			self.emit('open')
+		});
+	};
+
+	request(type, offset, iovecs, callback) {
+		if (typeof this.fd !== 'number') {
+			return this.once('open', function() {
+				this.request(type, offset, iovecs, callback);
+			});
+		}
+
+		switch (type) {
+			case constants.LKL_DEV_BLK_TYPE_READ:
+				// FIXME: we have to fill all the iovecs, not just the first
+				fs.read(this.fd, iovecs[0], 0, iovecs[0].length, offset, callback);
+				break;
+			case constants.LKL_DEV_BLK_TYPE_WRITE:
+				// FIXME: we have to persist all the iovecs, not just the first
+				fs.write(this.fd, iovecs[0], 0, iovecs[0].length, offset, callback);
+				break;
+			case constants.LKL_DEV_BLK_TYPE_FLUSH:
+			case constants.LKL_DEV_BLK_TYPE_FLUSH_OUT:
+				fs.fdatasync(this.fd, callback);
+				break;
+			default:
+				throw new Error("Unknown request type: " + type);
+		}
+	};
+
+	getCapacity(callback) {
+		if (typeof this.fd !== 'number') {
+			return this.once('open', function() {
+				this.getCapacity(callback);
+			});
+		}
+		fs.fstat(this.fd, function (err, stat) {
+			if (err) {
+				return callback(err);
+			}
+			callback(null, stat.size);
+		});
+	};
+}
+
+exports.FileDisk = FileDisk;

--- a/lib/lkl.js
+++ b/lib/lkl.js
@@ -1,38 +1,40 @@
 const bindings = require('bindings')('bindings');
-const constants = process.binding('constants').fs;
-const fs = require('fs');
 
 const lkl = exports;
 
 lkl.fs = require('./fs');
+lkl.disk = require('./disk');
 
 lkl.startKernelSync = function(memory) {
 	return bindings.startKernel(memory);
 };
 
-mounts = {};
+const mounts = {};
 
-lkl.mountSync = function(path, options) {
-	let flags = options.readOnly ? constants.O_RDONLY : constants.O_RDWR;
-	const partition = options.partition || 0;
-	let fd = fs.openSync(path, flags);
-	let ret = bindings.mount(
-		fd,
-		Boolean(options.readOnly),
-		options.fsType,
-		partition
+lkl.mount = function(disk, opts, callback) {
+	bindings.mount(
+		opts.readOnly,
+		opts.filesystem,
+		opts.partition,
+		disk.request.bind(disk),
+		disk.getCapacity.bind(disk),
+		function(err, info) {
+			if (err) {
+				return callback(err);
+			}
+
+			mounts[info.mountpoint] = {
+				diskId: info.diskId,
+				opts: opts
+			};
+
+			callback(null, info.mountpoint);
+		}
 	);
-
-	mounts[ret.mountpoint] = {
-		diskId: ret.diskId,
-		fd: fd
-	};
-
-	return ret.mountpoint;
 };
 
 lkl.umountSync = function(mountpoint) {
-	let info = mounts[mountpoint];
+	const info = mounts[mountpoint];
 	bindings.umount(info.diskId);
-	fs.closeSync(info.fd);
+	delete mounts[mountpoint];
 };

--- a/lib/lkl.js
+++ b/lib/lkl.js
@@ -12,10 +12,12 @@ lkl.startKernelSync = function(memory) {
 const mounts = {};
 
 lkl.mount = function(disk, opts, callback) {
+	const partition = opts.partition || 0;
+
 	bindings.mount(
 		opts.readOnly,
 		opts.filesystem,
-		opts.partition,
+		partition,
 		disk.request.bind(disk),
 		disk.getCapacity.bind(disk),
 		function(err, info) {
@@ -25,7 +27,7 @@ lkl.mount = function(disk, opts, callback) {
 
 			mounts[info.mountpoint] = {
 				diskId: info.diskId,
-				opts: opts
+				partition: partition
 			};
 
 			callback(null, info.mountpoint);
@@ -33,8 +35,13 @@ lkl.mount = function(disk, opts, callback) {
 	);
 };
 
-lkl.umountSync = function(mountpoint) {
+lkl.umount = function(mountpoint, callback) {
 	const info = mounts[mountpoint];
-	bindings.umount(info.diskId);
-	delete mounts[mountpoint];
+	bindings.umount(info.diskId, info.partition, function(err) {
+		if (err) {
+			return callback(err);
+		}
+		delete mounts[mountpoint];
+		callback(null);
+	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lkl",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "NodeJS native bindings to the Linux Kernel Library project",
   "author": "Petros Angelatos <petrosagg@resin.io>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublish": "publish-please guard"
   },
   "devDependencies": {
-    "async": "^2.1.4",
+    "bluebird": "^3.4.7",
     "mocha": "^2.2.5",
     "nan": "^2.0.5",
     "node-gyp": "^1.0.3",

--- a/src/async.cc
+++ b/src/async.cc
@@ -1,0 +1,68 @@
+#include "async.h"
+
+using namespace Nan;
+
+uv_async_t *async;
+uv_mutex_t lock;
+
+struct call_info_t {
+	void (*fn)(void *);
+	void *args;
+	uv_sem_t sem;
+};
+
+static void default_loop_entry(uv_async_t* handle) {
+	call_info_t *info = (call_info_t*) handle->data;
+
+	info->fn(info->args);
+	// Unlock run_on_default_loop
+	uv_sem_post(&info->sem);
+}
+
+void init_async() {
+	async = new uv_async_t;
+	uv_async_init(uv_default_loop(), async, default_loop_entry);
+	uv_mutex_init(&lock);
+}
+
+void run_on_default_loop(void (*fn)(void *), void *args) {
+	// This function needs to be mutex'd because uv_async_send can coalesce
+	// calls if called multiple times. This could potentially be avoided with a
+	// heap allocated queue that stores requests for the main thread but the
+	// benefit would be small.
+	uv_mutex_lock(&lock);
+
+	call_info_t info;
+	info.fn = fn;
+	info.args = args;
+	uv_sem_init(&info.sem, 0);
+
+	async->data = &info;
+	uv_async_send(async);
+
+	uv_sem_wait(&info.sem);
+	uv_mutex_unlock(&lock);
+}
+
+static NAN_METHOD(callback_wrapper) {
+	auto data = info.Data()->ToObject();
+
+	void (*fn)(NAN_METHOD_ARGS_TYPE, void *) = data->Get(0).As<v8::External>()->Value();
+	auto args = data->Get(1).As<v8::External>()->Value();
+
+	if (fn && args) {
+		// Ensure callback is called only once
+		Delete(data, 0);
+		Delete(data, 1);
+
+		fn(info, args);
+	}
+}
+
+v8::Local<v8::Function> make_callback(void (*fn)(NAN_METHOD_ARGS_TYPE, void *), void *args) {
+    auto data = New<v8::Object>();
+	data->Set(0, New<v8::External>(fn));
+	data->Set(1, New<v8::External>(args));
+
+	return New<v8::FunctionTemplate>(callback_wrapper, data)->GetFunction();
+}

--- a/src/async.h
+++ b/src/async.h
@@ -1,0 +1,9 @@
+#include <nan.h>
+
+using namespace Nan;
+
+void init_async();
+
+void run_on_default_loop(void (*fn)(void *), void *args);
+
+v8::Local<v8::Function> make_callback(void (*fn)(NAN_METHOD_ARGS_TYPE, void *), void *args);

--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -1,6 +1,10 @@
+#include "async.h"
 #include "node_lkl.h"
+#include "disk.h"
 
 NAN_MODULE_INIT(InitAll) {
+	init_async();
+
 	NAN_EXPORT(target, startKernel);
 	NAN_EXPORT(target, haltKernel);
 	NAN_EXPORT(target, mount);

--- a/src/disk.cc
+++ b/src/disk.cc
@@ -1,0 +1,225 @@
+extern "C" {
+	#include <lkl.h>
+	#include <lkl_host.h>
+}
+
+#include <nan.h>
+#include "async.h"
+
+#define SECTOR_SIZE 512
+
+using namespace Nan;
+
+typedef struct lkl_disk lkl_disk_t;
+typedef struct lkl_blk_req lkl_blk_req_t;
+
+/*
+ * Defines the Javascript counterparts of lkl_dev_blk_ops
+ */
+struct js_ops_t {
+	Callback* request;
+	Callback* get_capacity;
+};
+
+/*
+ * state structs are used to pass around variables between functions running in
+ * different threads and times. They are created in the stack of the first
+ * function and a pointer is passed around while the first function waits for
+ * all the others to finish.
+ */
+struct get_capacity_state_t {
+	int ret;
+	lkl_disk_t disk;
+	unsigned long long *res;
+	uv_sem_t js_sem;
+};
+
+struct request_state_t {
+	int ret;
+	lkl_disk_t disk;
+	lkl_blk_req_t *req;
+	uv_sem_t js_sem;
+};
+
+static void get_capacity_done(NAN_METHOD_ARGS_TYPE info, get_capacity_state_t* s) {
+	if (info[0]->IsNull()) {
+		s->ret = 0;
+		*(s->res) = info[1]->IntegerValue();
+	} else {
+		s->ret = info[0]->IntegerValue();
+		*(s->res) = 0;
+	}
+
+	// Unblocks the original lkl thread
+	uv_sem_post(&s->js_sem);
+}
+
+static void get_capacity(get_capacity_state_t *s) {
+	HandleScope scope;
+	auto js_ops = static_cast<js_ops_t*>(s->disk.handle);
+
+	v8::Local<v8::Value> argv[] = {
+		make_callback(get_capacity_done, static_cast<void *>(s))
+	};
+
+	js_ops->get_capacity->Call(1, argv);
+}
+
+static void request_done(NAN_METHOD_ARGS_TYPE info, request_state_t* s) {
+	if (info[0]->IsNull()) {
+		s->ret = 0;
+	} else {
+		s->ret = info[0]->IntegerValue();
+	}
+
+	// Unblocks the original lkl thread
+	uv_sem_post(&s->js_sem);
+}
+
+static void noop(char *data, void *hint) {}
+
+static void request(request_state_t *s) {
+	HandleScope scope;
+	int i;
+
+	// Convert iovecs to Buffer objects pointing to the same memory
+	auto iovecs = New<v8::Array>();
+	for (i = 0; i < s->req->count; i++) {
+		// We pass `noop` as the free callback because memory is managed by lkl
+		// and we don't want V8 to run free() on it
+		Set(iovecs, i, NewBuffer((char*) s->req->buf[i].iov_base,
+								 s->req->buf[i].iov_len, noop, NULL).ToLocalChecked());
+	}
+
+	auto js_ops = static_cast<js_ops_t*>(s->disk.handle);
+
+	v8::Local<v8::Value> argv[] = {
+		New<v8::Number>(s->req->type),
+		New<v8::Number>(s->req->sector * SECTOR_SIZE),
+		iovecs,
+		make_callback(request_done, static_cast<void *>(s)),
+	};
+
+	js_ops->request->Call(4, argv);
+}
+
+static int js_get_capacity_entry(lkl_disk_t disk, unsigned long long *res) {
+	get_capacity_state_t s;
+	s.disk = disk;
+	s.res = res;
+	uv_sem_init(&s.js_sem, 0);
+
+	// We are in a lkl thread, we can't call JS functions directly
+	run_on_default_loop(get_capacity, &s);
+
+	uv_sem_wait(&s.js_sem);
+	uv_sem_destroy(&s.js_sem);
+	return s.ret;
+}
+
+static int js_request_entry(lkl_disk_t disk, lkl_blk_req_t *req) {
+	request_state_t s;
+	s.disk = disk;
+	s.req = req;
+	uv_sem_init(&s.js_sem, 0);
+
+	// We are in a lkl thread, we can't call JS functions directly
+	run_on_default_loop(request, &s);
+
+	uv_sem_wait(&s.js_sem);
+	uv_sem_destroy(&s.js_sem);
+	return s.ret;
+}
+
+struct lkl_dev_blk_ops lkl_js_disk_ops = {
+	.get_capacity = js_get_capacity_entry,
+	.request = js_request_entry,
+};
+
+class MountWorker : public AsyncWorker {
+	public:
+		MountWorker(NAN_METHOD_ARGS_TYPE info, Callback *callback)
+		: AsyncWorker(callback) {
+			readonly = info[0]->BooleanValue();
+
+			Utf8String fs_type_(info[1]);
+			strncpy(fs_type, *fs_type_, sizeof(fs_type) - 1);
+			fs_type[sizeof(fs_type) - 1] = '\0';
+
+			part = info[2]->Uint32Value();
+
+			// FIXME: delete this object when the disk is unmounted
+			auto js_ops = new js_ops_t;
+			js_ops->request = new Callback(info[3].As<v8::Function>());
+			js_ops->get_capacity = new Callback(info[4].As<v8::Function>());
+
+			disk.ops = &lkl_js_disk_ops;
+			disk.handle = js_ops;
+		}
+
+		~MountWorker() {}
+
+		void Execute () {
+			disk_id = lkl_disk_add(&disk);
+			ret = lkl_mount_dev(disk_id, part, fs_type, readonly ? LKL_MS_RDONLY :
+								0, NULL, mountpoint, sizeof(mountpoint));
+		}
+
+		void HandleOKCallback () {
+			HandleScope scope;
+
+			if (ret < 0) {
+				v8::Local<v8::Value> argv[] = {
+					New<v8::Number>(-ret)
+				};
+				callback->Call(1, argv);
+			} else {
+				v8::Local<v8::Object> ret2 = New<v8::Object>();
+				Set(ret2, New("mountpoint").ToLocalChecked(), New(mountpoint).ToLocalChecked());
+				Set(ret2, New("diskId").ToLocalChecked(), New(disk_id));
+				v8::Local<v8::Value> argv[] = { Null(), ret2 };
+				callback->Call(2, argv);
+			}
+		}
+
+	private:
+		long ret;
+		bool readonly;
+		unsigned int part;
+		char fs_type[10];
+		char mountpoint[32];
+		unsigned int disk_id;
+		lkl_disk_t disk;
+};
+
+NAN_METHOD(mount) {
+	if (info.Length() != 6) {
+		ThrowTypeError("Wrong number of arguments");
+		return;
+	}
+
+	if (info[5]->IsFunction()) {
+		Callback *callback = new Callback(info[5].As<v8::Function>());
+		AsyncQueueWorker(new MountWorker(info, callback));
+	}
+}
+
+NAN_METHOD(umount) {
+	unsigned int disk_id;
+	int ret;
+
+	if (info.Length() != 1) {
+		ThrowTypeError("Wrong number of arguments");
+		return;
+	}
+
+	disk_id = info[0]->IntegerValue();
+
+	lkl_sys_sync();
+	ret = lkl_umount_dev(disk_id, 0, 0, 1000);
+	if (ret < 0) {
+		ThrowError(ErrnoException(-ret));
+	} else {
+		info.GetReturnValue().Set(New(ret));
+	}
+}

--- a/src/disk.cc
+++ b/src/disk.cc
@@ -248,21 +248,13 @@ class UmountWorker : public AsyncWorker {
 };
 
 NAN_METHOD(umount) {
-	unsigned int disk_id;
-	int ret;
-
-	if (info.Length() != 1) {
+	if (info.Length() != 3) {
 		ThrowTypeError("Wrong number of arguments");
 		return;
 	}
 
-	disk_id = info[0]->IntegerValue();
-
-	lkl_sys_sync();
-	ret = lkl_umount_dev(disk_id, 0, 0, 1000);
-	if (ret < 0) {
-		ThrowError(ErrnoException(-ret));
-	} else {
-		info.GetReturnValue().Set(New(ret));
+	if (info[2]->IsFunction()) {
+		Callback *callback = new Callback(info[2].As<v8::Function>());
+		AsyncQueueWorker(new UmountWorker(info, callback));
 	}
 }

--- a/src/disk.h
+++ b/src/disk.h
@@ -1,0 +1,4 @@
+#include <nan.h>
+
+NAN_METHOD(mount);
+NAN_METHOD(umount);

--- a/src/linux/arch/lkl/Makefile
+++ b/src/linux/arch/lkl/Makefile
@@ -35,6 +35,7 @@ lkl.o: vmlinux
 
 arch/lkl/include/generated/uapi/asm/syscall_defs.h: vmlinux
 	$(OBJCOPY) -j .syscall_defs -O binary --set-section-flags .syscall_defs=alloc $< $@
+	sed -i 's/\x0//g' $@
 
 install: lkl.o __headers arch/lkl/include/generated/uapi/asm/syscall_defs.h
 	@echo "  INSTALL	$(INSTALL_PATH)/lib/lkl.o"

--- a/src/linux/arch/lkl/include/asm/Kbuild
+++ b/src/linux/arch/lkl/include/asm/Kbuild
@@ -74,4 +74,3 @@ generic-y += trace_clock.h
 generic-y += uaccess.h
 generic-y += unaligned.h
 generic-y += word-at-a-time.h
-generic-y += xor.h

--- a/src/linux/arch/lkl/include/asm/thread_info.h
+++ b/src/linux/arch/lkl/include/asm/thread_info.h
@@ -49,7 +49,6 @@ void free_thread_stack(struct task_struct *tsk);
 
 void threads_init(void);
 void threads_cleanup(void);
-void threads_cnt_dec(void);
 
 #define TIF_SYSCALL_TRACE		0
 #define TIF_NOTIFY_RESUME		1

--- a/src/linux/arch/lkl/include/asm/xor.h
+++ b/src/linux/arch/lkl/include/asm/xor.h
@@ -1,0 +1,8 @@
+#ifndef _ASM_LKL_XOR_H
+#define _ASM_LKL_XOR_H
+
+#include <asm-generic/xor.h>
+
+#define XOR_SELECT_TEMPLATE(x) (&xor_block_8regs)
+
+#endif /* _ASM_LKL_XOR_H */

--- a/src/linux/arch/lkl/kernel/setup.c
+++ b/src/linux/arch/lkl/kernel/setup.c
@@ -160,7 +160,6 @@ static int lkl_run_init(struct linux_binprm *bprm)
 	init_pid_ns.child_reaper = 0;
 
 	syscalls_init();
-	threads_cnt_dec();
 
 	lkl_ops->sem_up(init_sem);
 	lkl_ops->thread_exit();

--- a/src/linux/tools/lkl/include/lkl.h
+++ b/src/linux/tools/lkl/include/lkl.h
@@ -85,6 +85,11 @@ const char *lkl_strerror(int err);
 void lkl_perror(char *msg, int err);
 
 /**
+ * struct lkl_dev_blk_ops - block device host operations, defined in lkl_host.h.
+ */
+struct lkl_dev_blk_ops;
+
+/**
  * lkl_disk - host disk handle
  *
  * @dev - a pointer to 'virtio_blk_dev' structure for this disk
@@ -97,6 +102,7 @@ struct lkl_disk {
 		int fd;
 		void *handle;
 	};
+	struct lkl_dev_blk_ops *ops;
 };
 
 /**

--- a/src/linux/tools/lkl/lib/virtio_blk.c
+++ b/src/linux/tools/lkl/lib/virtio_blk.c
@@ -87,7 +87,10 @@ int lkl_disk_add(struct lkl_disk *disk)
 	dev->dev.config_data = &dev->config;
 	dev->dev.config_len = sizeof(dev->config);
 	dev->dev.ops = &blk_ops;
-	dev->ops = &lkl_dev_blk_ops;
+	if (disk->ops)
+		dev->ops = disk->ops;
+	else
+		dev->ops = &lkl_dev_blk_ops;
 	dev->disk = *disk;
 
 	ret = dev->ops->get_capacity(*disk, &capacity);

--- a/src/node_lkl.cc
+++ b/src/node_lkl.cc
@@ -20,64 +20,6 @@ NAN_METHOD(haltKernel) {
 	lkl_sys_halt();
 }
 
-NAN_METHOD(mount) {
-	bool ro;
-	char mpoint[32];
-	unsigned int disk_id;
-	unsigned int part;
-	struct lkl_disk disk;
-	long ret;
-
-	if (info.Length() != 4) {
-		Nan::ThrowTypeError("Wrong number of arguments");
-		return;
-	}
-
-	disk.ops = NULL;
-	disk.fd = info[0]->Uint32Value();
-	ro = info[1]->BooleanValue();
-	Nan::Utf8String fs_type(info[2]);
-	part = info[3]->Uint32Value();
-
-	disk_id = lkl_disk_add(&disk);
-
-	ret = lkl_mount_dev(
-		disk_id,
-		part,
-		*fs_type,
-		ro ? LKL_MS_RDONLY : 0,
-		NULL,
-		mpoint,
-		sizeof(mpoint)
-	);
-
-	if (ret < 0) {
-		Nan::ThrowError(Nan::ErrnoException(-ret));
-		return;
-	}
-
-	v8::Local<v8::Object> ret2 = Nan::New<v8::Object>();
-	Nan::Set(ret2, Nan::New<v8::String>("mountpoint").ToLocalChecked(),
-				   Nan::New<v8::String>(mpoint).ToLocalChecked());
-	Nan::Set(ret2, Nan::New<v8::String>("diskId").ToLocalChecked(),
-				   Nan::New<v8::Number>(disk_id));
-	info.GetReturnValue().Set(ret2);
-}
-
-NAN_METHOD(umount) {
-	unsigned int disk_id;
-
-	if (info.Length() != 1) {
-		Nan::ThrowTypeError("Wrong number of arguments");
-		return;
-	}
-
-	disk_id = info[0]->BooleanValue();
-
-	lkl_sys_sync();
-	lkl_umount_dev(disk_id, 0, 0, 1000);
-}
-
 class SyscallWorker : public Nan::AsyncWorker {
 	public:
 		SyscallWorker(Nan::NAN_METHOD_ARGS_TYPE info, Nan::Callback *callback)

--- a/src/node_lkl.cc
+++ b/src/node_lkl.cc
@@ -33,6 +33,7 @@ NAN_METHOD(mount) {
 		return;
 	}
 
+	disk.ops = NULL;
 	disk.fd = info[0]->Uint32Value();
 	ro = info[1]->BooleanValue();
 	Nan::Utf8String fs_type(info[2]);

--- a/src/node_lkl.h
+++ b/src/node_lkl.h
@@ -2,6 +2,4 @@
 
 NAN_METHOD(startKernel);
 NAN_METHOD(haltKernel);
-NAN_METHOD(mount);
-NAN_METHOD(umount);
 NAN_METHOD(syscall);

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ describe('node-lkl', function() {
 
 	describe('fs', function() {
 		before(function(done) {
-			self = this;
+			const self = this;
 
 			fs.createReadStream(RAW_FS_PATH)
 			.pipe(fs.createWriteStream(TMP_RAW_FS_PATH))
@@ -84,7 +84,7 @@ describe('node-lkl', function() {
 		});
 
 		describe('.access()', function() {
-			let createFileWithPerms = function(file, mode) {
+			const createFileWithPerms = function(file, mode) {
 				// FIXME: remove the catch clause once unlink gets implemented
 				return lkl.fs.unlinkAsync(file).catch(function() {})
 				.then(function() {


### PR DESCRIPTION
This PR re-vendors linux to include support of the new lkl_disk API that allows the caller to supply custom read/write functions to the underlying disk storage. The new version also has ~400ms faster startup due to short-circuiting the XOR runtime performance tests.

To support JS disk operations the code flow needs to go through a few hoops that I'll try to explain here.

When a disk is added to the lkl kernel, an `lkl_dev_blk_ops` structure is associated with it that defines the functions that will serve I/O requests when the filesystem needs them. The problem is that those functions will be invoked in a lkl thread and therefore cannot call any JS functions.

Let's follow a full cycle of a call to ops.request().

First, `js_request_entry()` is called in a lkl thread by the kernel. This function has to fulfill the request *synchronously*. To do that, it creates a semaphore(`js_sem`) and runs `request()` in the main loop using
`run_in_default_loop()`. After that call it waits on the semaphore indefinitely until the some other thread posts to it.

Now `request()`, which is running on the main loop, can call the JS function (`js_ops->request()`) that was supplied by the user. This is non-blocking and `request()` will return as soon as the user's function
(which is also async) returns. In order for the native side to be notified when the user has finished processing the request, `request()` passes a callback that is associated with a C++ function (`request_done`) and a state. The state includes the original `js_sem`.

At some point, the user is ready to return control to lkl and calls the supplied callback. This causes `request_done()` to run. This function will process the user's data passed in the callback and finally do a
`uv_sem_post(&js_sem)`. This unblocks the `js_request_entry()` call and control is returned to lkl.

There are two noteworthy things to mention about this process. Since the original `js_request_entry()` call is waiting for all the others to finish before returning, we can store all the state in the stack and
pass pointers pointing to its stack around. This avoids heap allocations and having to manually free memory. A side effect of this is that we have to ensure that the callback is not called twice, since the second time the state will be invalid and will be pointing to invalid memory. To accomplish that the callback self-destructs its state the first time it runs.