### PR TITLE
mount, umount and syscall no longer use the libuv threadpool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "6"
 env:
-  - CXX=g++-4.8
+  - CXX=g++-4.8 UV_THREADPOOL_SIZE=1
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -149,11 +149,6 @@ functionality. This is how it looks like with node-lkl:
     +------------+
 ```
 
-Limitations
------------
-
-This project can not work with an `UV_THREADPOOL_SIZE` env var smaller than `2`.
-
 Support
 -------
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,7 @@
 				"src/node_lkl.cc",
 				"src/disk.cc",
 				"src/async.cc",
+				"src/worker.cc",
 				"src/bindings.cc"
 			],
 			'actions': [

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -3,28 +3,14 @@
 const async = require('async');
 
 /*
-Node uses a thread pool for all its fs operations.
-We use the same threadpool for 3 things we do with lkl:
+We use threads for  the following actions:
  * mount
  * umount
  * syscall
 
-These 3 actions need to do fs operations.
-So we have to make sure we leave at least one thread of the threadpool free to
-avoid deadlocks.
-For example: all threadpool threads busy with mount calls waiting for a thread
-to be available for an fs operation.
-
-NOTE: node-lkl can not work with UV_THREADPOOL_SIZE < 2 .
+We want to avoid threads accumulating if a callback is not called so we use
+only one thread at a time.
 */
-
-function maxThreads() {
-	let poolSize = parseInt(process.env.UV_THREADPOOL_SIZE);
-	if (isNaN(poolSize)) {
-		poolSize = 4;  // default in libuv
-	}
-	return poolSize - 1;
-};
 
 const queue = async.queue(function(task, callback) {
 	const cb = task.args.pop();
@@ -32,7 +18,7 @@ const queue = async.queue(function(task, callback) {
 		cb(err, value);
 		callback(err);
 	});
-}, maxThreads());
+}, 1);
 
 exports.addOperation = function(method, args) {
 	queue.push({ method: method, args: args })

--- a/lib/syscall.js
+++ b/lib/syscall.js
@@ -16,7 +16,7 @@ function syscall() {
 		args[i] = 0;
 	}
 	// add the callback as last argument
-	args[7] = arguments[arguments.length - 1]
+	args[7] = arguments[arguments.length - 1];
 	queue.addOperation(bindings.syscall, args)
 }
 

--- a/src/async.cc
+++ b/src/async.cc
@@ -5,12 +5,6 @@ using namespace Nan;
 uv_async_t *async = NULL;
 uv_mutex_t lock;
 
-struct call_info_t {
-	void (*fn)(void *);
-	void *args;
-	uv_sem_t sem;
-};
-
 static void default_loop_entry(uv_async_t* handle) {
 	call_info_t *info = (call_info_t*) handle->data;
 

--- a/src/async.h
+++ b/src/async.h
@@ -2,6 +2,12 @@
 
 using namespace Nan;
 
+struct call_info_t {
+	void (*fn)(void *);
+	void *args;
+	uv_sem_t sem;
+};
+
 void init_async();
 
 void close_async();

--- a/src/disk.cc
+++ b/src/disk.cc
@@ -5,6 +5,7 @@ extern "C" {
 
 #include <nan.h>
 #include "async.h"
+#include "worker.h"
 
 #define SECTOR_SIZE 512
 
@@ -136,125 +137,150 @@ struct lkl_dev_blk_ops lkl_js_disk_ops = {
 	.request = js_request_entry,
 };
 
-class MountWorker : public AsyncWorker {
-	public:
-		MountWorker(NAN_METHOD_ARGS_TYPE info, Callback *callback)
-		: AsyncWorker(callback) {
-			readonly = info[0]->BooleanValue();
-
-			Utf8String fs_type_(info[1]);
-			strncpy(fs_type, *fs_type_, sizeof(fs_type) - 1);
-			fs_type[sizeof(fs_type) - 1] = '\0';
-
-			part = info[2]->Uint32Value();
-
-			// FIXME: delete this object when the disk is unmounted
-			auto js_ops = new js_ops_t;
-			js_ops->request = new Callback(info[3].As<v8::Function>());
-			js_ops->get_capacity = new Callback(info[4].As<v8::Function>());
-
-			disk.ops = &lkl_js_disk_ops;
-			disk.handle = js_ops;
-		}
-
-		~MountWorker() {}
-
-		void Execute () {
-			disk_id = lkl_disk_add(&disk);
-			ret = lkl_mount_dev(
-					disk_id,
-					part,
-					fs_type,
-					readonly ? LKL_MS_RDONLY : 0, NULL,
-					mountpoint,
-					sizeof(mountpoint)
-			);
-		}
-
-		void HandleOKCallback () {
-			HandleScope scope;
-
-			if (ret < 0) {
-				v8::Local<v8::Value> argv[] = {
-					ErrnoException(-ret)
-				};
-				callback->Call(1, argv);
-			} else {
-				v8::Local<v8::Object> ret2 = New<v8::Object>();
-				Set(ret2, New("mountpoint").ToLocalChecked(), New(mountpoint).ToLocalChecked());
-				Set(ret2, New("diskId").ToLocalChecked(), New(disk_id));
-				v8::Local<v8::Value> argv[] = { Null(), ret2 };
-				callback->Call(2, argv);
-			}
-		}
-
-	private:
-		long ret;
-		bool readonly;
-		unsigned int part;
-		char fs_type[10];
-		char mountpoint[32];
-		unsigned int disk_id;
-		lkl_disk_t disk;
+struct mount_state_t {
+	long ret;
+	unsigned int disk_id;
+	char* mountpoint;
+	Callback *callback;
 };
+
+static void mount_callback(mount_state_t *s) {
+	HandleScope scope;
+	if (s->ret < 0) {
+		v8::Local<v8::Value> argv[] = {ErrnoException(-s->ret)};
+		s->callback->Call(1, argv);
+	} else {
+		v8::Local<v8::Object> ret2 = New<v8::Object>();
+		Set(
+			ret2,
+			New("mountpoint").ToLocalChecked(),
+			New(s->mountpoint).ToLocalChecked()
+		);
+		Set(ret2, New("diskId").ToLocalChecked(), New(s->disk_id));
+		v8::Local<v8::Value> argv[] = { Null(), ret2 };
+		s->callback->Call(2, argv);
+	}
+}
+
+struct mount_args_t {
+	lkl_disk_t disk;
+	bool readonly;
+	const char* fs_type;
+	unsigned int part;
+	Callback *callback;
+};
+
+void do_mount(mount_args_t* args) {
+	char mountpoint[32];
+	unsigned int disk_id = lkl_disk_add(&(args->disk));
+	long ret = lkl_mount_dev(
+		disk_id,
+		args->part,
+		args->fs_type,
+		args->readonly ? LKL_MS_RDONLY : 0, NULL,
+		mountpoint,
+		sizeof(mountpoint)
+	);
+	mount_state_t s = {ret, disk_id, mountpoint, args->callback};
+	run_on_default_loop(mount_callback, &s);
+	delete args->fs_type;
+	delete args->callback;
+	delete args;
+}
+
+void mount_entry(NAN_METHOD_ARGS_TYPE info) {
+	bool readonly = info[0]->BooleanValue();
+
+	char *fs_type = new char[10];
+	Utf8String fs_type_(info[1]);
+	unsigned int part = info[2]->Uint32Value();
+	strncpy(fs_type, *fs_type_, sizeof(fs_type) - 1);
+	fs_type[sizeof(fs_type) - 1] = '\0';
+
+	// FIXME: delete this object when the disk is unmounted
+	auto js_ops = new js_ops_t;
+	js_ops->request = new Callback(info[3].As<v8::Function>());
+	js_ops->get_capacity = new Callback(info[4].As<v8::Function>());
+
+	Callback *callback = new Callback(info[5].As<v8::Function>());
+
+	lkl_disk_t disk;
+	disk.ops = &lkl_js_disk_ops;
+	disk.handle = js_ops;
+
+	mount_args_t* args = new mount_args_t;
+	args->disk = disk;
+	args->readonly = readonly;
+	args->fs_type = fs_type;
+	args->part = part;
+	args->callback = callback;
+
+	run_on_worker_loop(do_mount, args);
+}
 
 NAN_METHOD(mount) {
 	if (info.Length() != 6) {
 		ThrowTypeError("Wrong number of arguments");
 		return;
 	}
+	if (!info[5]->IsFunction()) {
+		Nan::ThrowTypeError("A callback is required");
+		return;
+	}
+	mount_entry(info);
+}
 
-	if (info[5]->IsFunction()) {
-		Callback *callback = new Callback(info[5].As<v8::Function>());
-		AsyncQueueWorker(new MountWorker(info, callback));
+struct umount_state_t {
+	int ret;
+	Callback *callback;
+};
+
+static void umount_callback(umount_state_t *s) {
+	HandleScope scope;
+	if (s->ret < 0) {
+		v8::Local<v8::Value> argv[] = {ErrnoException(-s->ret)};
+		s->callback->Call(1, argv);
+	} else {
+		v8::Local<v8::Value> argv[] = {Null(), New<v8::Number>(s->ret)};
+		s->callback->Call(2, argv);
 	}
 }
 
-class UmountWorker : public AsyncWorker {
-	public:
-		UmountWorker(NAN_METHOD_ARGS_TYPE info, Callback *callback)
-		: AsyncWorker(callback) {
-			disk_id = info[0]->Uint32Value();
-			partition = info[1]->Uint32Value();
-		}
-
-		~UmountWorker() {}
-
-		void Execute () {
-			lkl_sys_sync();
-			ret = lkl_umount_dev(disk_id, partition, 0, 1000);
-		}
-
-		void HandleOKCallback () {
-			HandleScope scope;
-
-			if (ret < 0) {
-				v8::Local<v8::Value> argv[] = {
-					ErrnoException(-ret)
-				};
-				callback->Call(1, argv);
-			} else {
-				v8::Local<v8::Value> argv[] = {
-					Null(),
-					New<v8::Number>(ret)
-				};
-				callback->Call(2, argv);
-			}
-		}
-	private:
-		unsigned int disk_id;
-		unsigned int partition;
-		int ret;
+struct umount_args_t {
+	unsigned int disk_id;
+	unsigned int partition;
+	Callback *callback;
 };
+
+void do_umount(umount_args_t* args) {
+	lkl_sys_sync();
+	int ret = lkl_umount_dev(args->disk_id, args->partition, 0, 1000);
+	umount_state_t s = {ret, args->callback};
+	run_on_default_loop(umount_callback, &s);
+	delete args->callback;
+	delete args;
+}
+
+
+void umount_entry(NAN_METHOD_ARGS_TYPE info) {
+	unsigned int disk_id = info[0]->Uint32Value();
+	unsigned int partition = info[1]->Uint32Value();
+	Callback *callback = new Callback(info[2].As<v8::Function>());
+	umount_args_t* args = new umount_args_t;
+	args->disk_id = disk_id;
+	args->partition = partition;
+	args->callback = callback;
+	run_on_worker_loop(do_umount, args);
+}
 
 NAN_METHOD(umount) {
 	if (info.Length() != 3) {
 		ThrowTypeError("Wrong number of arguments");
 		return;
 	}
-
-	if (info[2]->IsFunction()) {
-		Callback *callback = new Callback(info[2].As<v8::Function>());
-		AsyncQueueWorker(new UmountWorker(info, callback));
+	if (!info[2]->IsFunction()) {
+		Nan::ThrowTypeError("A callback is required");
+		return;
 	}
+	umount_entry(info);
 }

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,0 +1,51 @@
+#include "async.h"
+#include "worker.h"
+
+uv_sem_t worker_ready_sem;
+uv_loop_t worker_loop;
+uv_thread_t worker_thread;
+uv_async_t worker_async;
+call_info_t worker_info;
+
+
+void worker_loop_entry(uv_async_t* handle) {
+	call_info_t *info = (call_info_t*) handle->data;
+	info->fn(info->args);
+}
+
+void worker_thread_start(void *arg) {
+	int ret;
+	ret = uv_loop_init(&worker_loop);
+	if (ret) {
+		abort();
+	}
+	ret = uv_async_init(&worker_loop, &worker_async, worker_loop_entry);
+	if (ret) {
+		abort();
+	}
+	uv_sem_post(&worker_ready_sem);
+	ret = uv_run(&worker_loop, UV_RUN_DEFAULT);
+	if (ret) {
+		abort();
+	}
+}
+
+void run_on_worker_loop(void (*func)(void*), void* args) {
+	worker_info.fn = func;
+	worker_info.args = args;
+	int ret = uv_async_send(&worker_async);
+	if (ret) {
+		abort();
+	}
+}
+
+void init_worker() {
+	int ret;
+	uv_sem_init(&worker_ready_sem, 0);
+	worker_async.data = &worker_info;
+	ret = uv_thread_create(&worker_thread, worker_thread_start, NULL);
+	if (ret) {
+		abort();
+	}
+	uv_sem_wait(&worker_ready_sem);
+}

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,0 +1,3 @@
+void init_worker();
+
+void run_on_worker_loop(void (*func)(void *), void *args);

--- a/test/index.js
+++ b/test/index.js
@@ -274,11 +274,22 @@ describe('node-lkl', function() {
 				this.doesNotExist = path.join(this.mountpoint, '__this_should_not_exist');
 				this.readOnlyFile = path.join(this.mountpoint, 'read_only_file');
 				this.readWriteFile = path.join(this.mountpoint, 'read_write_file');
-
 				return Promise.all([
 					createFileWithPerms(this.readOnlyFile, 0o444),
 					createFileWithPerms(this.readWriteFile, 0o666)
 				]);
+			});
+
+			it('should be able to create 20 files at once', function(done) {
+				const fname = path.join(this.mountpoint, 'file_number_')
+				const promises = []
+				for (let i=0; i < 20; i++) {
+					promises.push(createFileWithPerms(fname + i, 0o666))
+				}
+				return Promise.all(promises)
+				.then(function() {
+					done();
+				});
 			});
 
 			it('non existent file', function(done) {


### PR DESCRIPTION
We use a separate worker thread for that.
This makes the project work even with `UV_THREADPOOL_SIZE=1`

Change-Type: patch